### PR TITLE
Fix for duplicate item entries

### DIFF
--- a/CompactVendor.toc
+++ b/CompactVendor.toc
@@ -1,4 +1,4 @@
-## Interface: 110100
+## Interface: 110105
 ## IconAtlas: Banker
 ## Title: CompactVendor
 ## Notes: Compact Vendor converts your vendor frame into a compact scrollable list with a search box. Inspiration drawn from Tekkub's GnomishVendorShrinker.

--- a/core.lua
+++ b/core.lua
@@ -2191,6 +2191,13 @@ local MerchantScanner do
                 end
             end
         end
+        if not isFullUpdate and activeItems and numMerchantItems < #activeItems then
+            -- It's possible to end up with more items in the pool than we currently need. So we need to clean them up. #31
+            for index = numMerchantItems+1, #activeItems do
+                self.itemPool:Release(activeItems[index])
+            end
+        end
+
         self:UpdateCollection()
         if pending == 0 and not self.isReady then
             self.isReady = true


### PR DESCRIPTION
Fixes #31.

After a bit of debugging I was able to locate the issue in `MerchantScanner:UpdateMerchant()`.
In my case the itemPool got filled before the Vendor filter kicked in. (It's probably because more item data got initially requested than usual.)
So in my example there were like 61 items inside the itemPool. But the filtered vendor only shows 41 items. All async loaded items triggered the Update without isFullUpdate. So that's why those dangling MerchantItems were kept inside the pool with some some random states.
The fix is quite simple to release again all unused MerchantItems from the pool. At least that's what I came up with. There might be a better way to avoid that faulty state entirely.