### PR TITLE
Prevent calling heirloom/toy API for entries that aren't items

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1919,7 +1919,7 @@ local RefreshAndUpdateMerchantItemButton do
         self.itemLink = GetMerchantItemLink(index)
         self.merchantItemID = GetMerchantItemID(index)
         self.itemLinkOrID = self.itemLink or self.merchantItemID
-        self.isHeirloom = C_Heirloom and C_Heirloom.IsItemHeirloom(self.merchantItemID) ---@diagnostic disable-line: assign-type-mismatch
+        self.isHeirloom = self.merchantItemID and C_Heirloom and C_Heirloom.IsItemHeirloom(self.merchantItemID) ---@diagnostic disable-line: assign-type-mismatch
         self.isKnownHeirloom = self.isHeirloom and C_Heirloom and C_Heirloom.PlayerHasHeirloom(self.merchantItemID) ---@diagnostic disable-line: assign-type-mismatch
         self.showNonrefundablePrompt = C_MerchantFrame and C_MerchantFrame.IsMerchantItemRefundable and not C_MerchantFrame.IsMerchantItemRefundable(index)
         self.tintRed = not self.isPurchasable or (not self.isUsable and not self.isHeirloom)
@@ -1987,8 +1987,8 @@ local RefreshAndUpdateMerchantItemButton do
         self.isCosmeticBundleCollected,
         self.isCosmeticBundleNum,
         self.isCosmeticBundleNumMax = IsCosmeticBundleCollected(self.itemLink)
-        self.isToy = C_ToyBox and C_ToyBox.GetToyInfo(self.merchantItemID) and true
-        self.isToyCollected = PlayerHasToy and PlayerHasToy(self.merchantItemID)
+        self.isToy = self.merchantItemID and C_ToyBox and C_ToyBox.GetToyInfo(self.merchantItemID) and true
+        self.isToyCollected = self.merchantItemID and PlayerHasToy and PlayerHasToy(self.merchantItemID)
         self.isLearnable = self.isCosmetic or self.isCosmeticBundle or self:IsLearnable()
         self.tooltipRequirementsScannable = self:IsRequirementScannable()
         self.tooltipScannable = self.isLearnable or self.tooltipRequirementsScannable


### PR DESCRIPTION
Fixes #33 

Errors occur whenever non-items (such as currencies) are purchasable from vendors. This happens because a nil ItemID gets passed to the heirloom and toybox APIs. This PR fixes that, preventing nil from being sent to those APIs - these non-items won't be toys or heirlooms.

